### PR TITLE
WIP: Switch docs from from GPG Tools + Apple Mail to Mailvelope

### DIFF
--- a/src/installation/email.md
+++ b/src/installation/email.md
@@ -13,7 +13,6 @@ Either way, we need to take some careful steps to ensure Hush Line can use it an
 1. In your browser, head over to [mail.google.com](mail.google.com/) to create a new GMail account.
 2. Once created, turn on 2-factor authentication.
 3. Create an ["app password"](https://support.google.com/accounts/answer/185833?hl=en) for Hush Line to use. Write this down for later use.
-4. Open Apple Mail and add this new GMail account.
 
 ## Create a PGP key for this email account to use
 
@@ -25,15 +24,16 @@ Here's how I like to think of PGP: Once set up, you'll have a very special envel
 
 Now let's say we want to receive secret messages from your friend Bob. First, you give Bob plenty of your special envelopes. (We do not give Bob the letter opener, since you don't want Bob to be able to open mail intended for you.) Bob writes his message, places it in one of your envelopes, and sends it to you. When you receive the sealed envelope, you use your letter opener to open it, confidence that no one else was able to read its contents along the way. 
 
-### Creating our envelopes and letter opener (on a Mac)
+### Creating our envelopes and letter opener
 
 IMPORTANT: These next steps you'll need to do on the computer than you want to be able to read your Hush Line messages on. We're here going to assume it's a Mac. 
 
-To create our envelopes and letter opener,we're going to use some software called [Mailvelope](https://gpgtools.org/). 
+To create our envelopes and letter opener, we're going to use a browser extension called [Mailvelope](https://mailvelope.com/en/). 
 
 As you can probably guess, the envelopes and letter opener have more technical names in the PGP system. Anyone who knows your **public key** can make your envelopes and the letter opener is called your **private key**. A public key and a private key is called a key-pair.
 
-Once you've installed GPG Tools, open a tool called GPG Keychain. Click "New" at the top of the window to create a key-pair (a public and private key) for our new Hush Line email address. Enter your Hush Line email address. Then choose a strong password or passphrase for your PGP password -- this will protect your private key (letter opener).
+Use Mailvelope to create a new PGP key. **TO DO: Expand these instructions and add screenshots.**
+<!-- Once you've installed GPG Tools, open a tool called GPG Keychain. Click "New" at the top of the window to create a key-pair (a public and private key) for our new Hush Line email address. Enter your Hush Line email address. Then choose a strong password or passphrase for your PGP password -- this will protect your private key (letter opener). -->
 
 Your private key (letter opener) will be stored on the computer you're using to set up this email account. As mentioned above, this means that only someone using this computer will be able to read the messages sent to your Hush Line.
 
@@ -42,8 +42,7 @@ If you or someone else logged in to your Hush Line email address on a different 
 ### Uploading our public key (the envelopes)
 Next, we need to upload our public key to a website.
 
-You can do this with GPG Keychain by clicking "Upload Public Key". (Remember, it's fine to share your envelopes, but never share the letter opener [the private key].) You'll receive a confirmation email. Click the link to verify that you indeed have access to the new Hush Line email address.
-
-This address verification process will take you to a URL that you will need later. It should look something like `https://keys.openpgp.org/vks/v1/by-fingerprint/D278DD437B275C8668989A4B425C6C74405C3EB1`. This is essentially the URL for your public PGP key. For now, paste it into a note or text file. (If you didn't save it, you can visit [https://keys.openpgp.org](https://keys.openpgp.org/) and search for your Hush Line email address and find it that way).
+**TO DO: How to get public key from Mailvelope to Hush Line...**
+<!-- This address verification process will take you to a URL that you will need later. It should look something like `https://keys.openpgp.org/vks/v1/by-fingerprint/D278DD437B275C8668989A4B425C6C74405C3EB1`. This is essentially the URL for your public PGP key. For now, paste it into a note or text file. (If you didn't save it, you can visit [https://keys.openpgp.org](https://keys.openpgp.org/) and search for your Hush Line email address and find it that way). -->
 
 Next, we get to install Hush Line back on our Raspberry Pi.

--- a/src/installation/regular-use.md
+++ b/src/installation/regular-use.md
@@ -12,6 +12,6 @@ Now we need to get some messages from your community.
 
 To do this, share/publicize your Hush Line site URL to your community. Be sure to include a link to [download and install Tor Browser](https://torproject.org/download), which they'll need to access your Hush Line site. You can share this information via email, your work chat app, on social media platforms, fliers, and even business cards if appropriate.
 
-After that, all you need to do is monitor your Hush Line email address's inbox, using Apple Mail on the computer you set up your PGP keys on. When attempting to read a Hush Line message, you'll periodically be prompted to enter your PGP password again. 
+After that, all you need to do is monitor your Hush Line email address's inbox, using the computer you set up Mailvelope on. When attempting to read a Hush Line message, you may be periodically be prompted to enter your PGP password again. 
 
 Again, only people using this computer, who know your PGP password, will be able you read your Hush Line messages.


### PR DESCRIPTION
This is my Work In Progress PR for switching our docs from GPG Tools + Apple Mail over to [Mailvelope](https://mailvelope.com/en/). Mailvelope will serve as both our method for users to generate their PGP keys and for them to decrypt/read messages.

## Why
[This change is needed because Apple has stopped allowing plugins to Apple Mail in their latest version of macOS](https://gpgtools.org/sonoma). Though note that using Mailvelope may provide some other benefits.

## Still need TO DO
**TO DO**: Explain basic steps for creating a key-pair and decrypting mail using Mailvelope.