### PR TITLE
SSH user to lowercase `hush`

### DIFF
--- a/src/prereqs/raspberrypi.md
+++ b/src/prereqs/raspberrypi.md
@@ -37,9 +37,9 @@ Insert your microSD card into your computer, and then click `Choose Storage` and
 
 Before clicking Write, click on the Settings gear in the bottom right of the window. Configure the following settings:
 
-- Hostname = hushline
+- Hostname = `hushline`
 - Enable SSH with password authentication
-- User = Hush
+- User = `hush`
 - Set a strong password
 - Wifi settings
 


### PR DESCRIPTION
I don't know if SSH usernames are case-sensitive, but even if they're not, I think it's good to go with lowercase "hush" for user name, if for no other reason than to be consistent with this instruction later in the document:

> Enter `ssh hush@hushline.local`, and when prompted, enter the password you created in the first step.