### PR TITLE
Tell user to change image options to "always use"

### DIFF
--- a/src/prereqs/raspberrypi.md
+++ b/src/prereqs/raspberrypi.md
@@ -29,6 +29,7 @@ Insert your microSD card into your computer, and then click `Choose Storage` and
 
 Before clicking Write, click on the Settings gear in the bottom right of the window. Configure the following settings:
 
+- Change "Image customization options" setting to "to always use"
 - Hostname = hushline
 - Enable SSH with password authentication
 - User = Hush


### PR DESCRIPTION
I assume this is important. My Pi Imager defaulted to the other option (I forget what it was now). 

![to-always-use](https://github.com/scidsg/hushline-docs/assets/4871664/786629f4-2e04-4af2-beb9-1fa6d3e2d346)
