### PR TITLE
Put hush and hushline in `code blocks`

### DIFF
--- a/src/prereqs/raspberrypi.md
+++ b/src/prereqs/raspberrypi.md
@@ -30,9 +30,9 @@ Insert your microSD card into your computer, and then click `Choose Storage` and
 
 Before clicking Write, click on the Settings gear in the bottom right of the window. Configure the following settings:
 
-- Hostname = hushline
+- Hostname = `hushline`
 - Enable SSH with password authentication
-- User = hush
+- User = `hush`
 - Set a strong password
 - Add wifi settings
 


### PR DESCRIPTION
Put `hush` and `hushline` in code blocks, signaling to user that they need to use `hushline` for hostname and `hush` as username exactly (e.g. case sensitive).