### PR TITLE
Remove unnecessary update system step from Pi prereqs

### DIFF
--- a/src/prereqs/raspberrypi.md
+++ b/src/prereqs/raspberrypi.md
@@ -54,12 +54,4 @@ Enter `ssh hush@hushline.local`, and when prompted, enter the password you creat
 
 <img src="../img/21-terminal-login.png">
 
-### 5. Update your system
-
-The last thing we need to do is to update our system. First, we'll give ourselves admin priviledges, then perform the update:
-
-Enter `sudo su`, then `apt update && apt -y dist-upgrade && apt -y autoremove`.
-
-<img src="../img/21-update.png">
-
 🎉 That's it, you're ready to get started with Raspberry Pi!


### PR DESCRIPTION
[Our installation script does this system updating for the user](https://github.com/scidsg/hushline/blob/main/scripts/install.sh#L24-L25). So I don't think we need to ask them to do it as a prereq? 

I'm kind of basing this on the philosophy that, all other things equal, fewer steps for the user == better.