### PR TITLE
Add repo orientation docs for hushline-docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+# AGENTS.md
+
+This file provides operating guidance for coding agents working in the `hushline-docs` repository.
+
+## Scope
+
+- Applies to the entire repository unless a deeper `AGENTS.md` exists in a subdirectory.
+
+## What This Repo Is
+
+- This is the standalone repository for the Hush Line documentation website.
+- It is not the main Hush Line application repo.
+- The published site lives at `https://hushline.app/library/`.
+- The Docusaurus project itself lives under the [`docs/`](./docs) directory.
+
+## Primary Goal
+
+- Make the docs site clearer, more accurate, and easier to maintain without breaking the published docs experience.
+
+## Start Here
+
+If you are new to this repo, read in this order:
+
+1. [`README.md`](./README.md)
+2. [`docs/README.md`](./docs/README.md)
+3. [`docs/docusaurus.config.js`](./docs/docusaurus.config.js)
+4. [`docs/sidebars.js`](./docs/sidebars.js)
+
+## Repository Map
+
+| Path | Purpose |
+| --- | --- |
+| `docs/docs/` | Documentation content pages |
+| `docs/blog/` | Blog posts, media, authors, tags |
+| `docs/src/pages/` | Homepage and standalone pages |
+| `docs/src/components/` | Reusable React components for the site |
+| `docs/src/css/` | Custom site CSS |
+| `docs/static/` | Static assets copied through at build time |
+| `docs/docusaurus.config.js` | Global site config, navbar/footer, base URL, metadata |
+| `docs/sidebars.js` | Docs sidebar generation/configuration |
+| `docs/package.json` | Local scripts and dependency versions |
+
+## Local Commands
+
+Run these from `docs/`, not from the repo root:
+
+- install deps: `npm install`
+- dev server: `npm run start -- --host 127.0.0.1 --port 3001`
+- production build: `npm run build`
+- serve built output: `npm run serve -- --host 127.0.0.1 --port 3001`
+
+Local site URL:
+
+- `http://127.0.0.1:3001/library/`
+
+The `/library/` path matters because the site base URL is configured to `/library/`.
+
+## Editing Rules
+
+- Keep changes focused on the requested docs/site task.
+- Do not rewrite large sections of doc content unless the task asks for it.
+- Preserve existing frontmatter, slugs, and category structure unless a routing/navigation change is explicitly needed.
+- Prefer updating content in place over moving files.
+- Be careful with absolute URLs, internal links, and image paths because the site is served under `/library/`.
+
+## Generated and Local Artifact Paths
+
+Treat these as generated or local-only unless the task specifically targets them:
+
+- `docs/build/`
+- `docs/.docusaurus/`
+- `docs/node_modules/`
+- `docs/static/img/screenshots/`
+
+This repo may also contain unrelated in-progress local changes to doc pages or screenshots. Always check `git status` first and do not revert or overwrite user work.
+
+## Common Task Entry Points
+
+| Task | Start here |
+| --- | --- |
+| Update documentation copy | matching file under `docs/docs/` |
+| Update a blog post | matching file under `docs/blog/` |
+| Change homepage content/layout | `docs/src/pages/index.js` and `docs/src/components/` |
+| Change site-wide styling | `docs/src/css/custom.css` and component CSS modules |
+| Change navbar/footer/metadata | `docs/docusaurus.config.js` |
+| Change sidebar behavior | `docs/sidebars.js` |
+| Debug local startup | `docs/README.md`, `docs/package.json` |
+
+## Validation
+
+For meaningful site changes, prefer this validation sequence from `docs/`:
+
+1. `npm run build`
+2. `npm run serve -- --host 127.0.0.1 --port 3001`
+
+If the task is content-only and you do not build locally, say so explicitly.
+
+## Relationship to the Main App Repo
+
+- Main application repo: `scidsg/hushline`
+- This repo documents that product, but it does not contain the Flask app, backend routes, or application tests.
+- If a task requires changing actual product behavior, it belongs in the main app repo, not here.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# hushline-docs
+
+Standalone repository for the Hush Line documentation site.
+
+This repo contains the source for the public docs and blog published at:
+
+- `https://hushline.app/library/`
+
+The actual Docusaurus app lives inside the [`docs/`](./docs) directory, so most development commands run from there rather than from the repo root.
+
+## What Lives Here
+
+| Path | Purpose |
+| --- | --- |
+| [`docs/docs/`](./docs/docs) | Documentation content shown in the Library sidebar |
+| [`docs/blog/`](./docs/blog) | Blog posts, cover images, and author/tag metadata |
+| [`docs/src/`](./docs/src) | Docusaurus homepage React code and custom site components |
+| [`docs/static/`](./docs/static) | Static assets copied through to the built site |
+| [`docs/docusaurus.config.js`](./docs/docusaurus.config.js) | Site config, navbar/footer, base URL, metadata |
+| [`docs/sidebars.js`](./docs/sidebars.js) | Docs sidebar configuration |
+| [`docs/package.json`](./docs/package.json) | Node scripts and Docusaurus dependency versions |
+| [`docs/README.md`](./docs/README.md) | Local development details for the Docusaurus app |
+| [`AGENTS.md`](./AGENTS.md) | Agent-facing repo map, workflow rules, and do-not-touch guidance |
+
+## Mental Model
+
+This repo is not the Hush Line application itself. It is the documentation website for that application.
+
+That means:
+
+- content changes usually happen in Markdown under `docs/docs/` or `docs/blog/`
+- homepage/layout/theme changes usually happen under `docs/src/`, `docs/src/css/`, or `docs/docusaurus.config.js`
+- the site is served under the `/library/` base path, not `/`
+- local development commands should be run from `docs/`
+
+## Local Development
+
+From the `docs/` directory:
+
+```bash
+npm install
+npm run start -- --host 127.0.0.1 --port 3001
+```
+
+Then open:
+
+- `http://127.0.0.1:3001/library/`
+
+To verify a production-style build:
+
+```bash
+npm run build
+npm run serve -- --host 127.0.0.1 --port 3001
+```
+
+## Editing Guidance
+
+- For doc content changes, start in `docs/docs/`.
+- For blog work, start in `docs/blog/`.
+- For homepage or presentation work, start in `docs/src/` and `docs/src/css/`.
+- For navigation, links, metadata, or base path changes, inspect `docs/docusaurus.config.js` and `docs/sidebars.js`.
+
+## Generated and Local-Only Paths
+
+This repo may contain large local artifact directories during active work. Treat these as generated unless the task explicitly targets them:
+
+- `docs/build/`
+- `docs/.docusaurus/`
+- `docs/node_modules/`
+- `docs/static/img/screenshots/`
+
+There may also be in-progress local doc edits in the worktree. Check `git status` before making changes and do not overwrite unrelated work.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,26 @@
 # Hush Line Docs Site
 
-This site is built with [Docusaurus](https://docusaurus.io/) and lives in this `docs/` directory.
+This directory contains the Docusaurus app for the public Hush Line Library site.
+
+Published URL:
+
+- `https://hushline.app/library/`
+
+The repository root contains high-level repo guidance in [`../README.md`](../README.md) and [`../AGENTS.md`](../AGENTS.md). This file is the practical guide for running and editing the Docusaurus site itself.
+
+## Directory Map
+
+| Path | Purpose |
+| --- | --- |
+| `docs/` | Markdown docs content rendered in the Library |
+| `blog/` | Blog posts and related media |
+| `src/pages/` | Homepage and standalone pages |
+| `src/components/` | Reusable React components |
+| `src/css/` | Site-wide custom CSS |
+| `static/` | Static files copied directly into the built site |
+| `docusaurus.config.js` | Site config, metadata, navbar, footer, base URL |
+| `sidebars.js` | Sidebar generation/configuration |
+| `package.json` | Local scripts and dependency versions |
 
 ## Prerequisites
 
@@ -9,7 +29,7 @@ This site is built with [Docusaurus](https://docusaurus.io/) and lives in this `
 
 ## Install
 
-Run from the `docs/` directory:
+Run from this `docs/` directory:
 
 ```bash
 npm install
@@ -27,8 +47,9 @@ Open:
 
 Notes:
 
-- The site base URL is `/library/`, so use `/library/` in local URLs.
-- If port `3000` is in use, keep using `3001` (or another free port).
+- The site base URL is `/library/`, so local URLs must include `/library/`.
+- Commands should be run from `docs/`, not the repository root.
+- If port `3000` is in use, keep using `3001` or another free port.
 
 ## Production Build + Local Serve
 
@@ -43,8 +64,30 @@ Open:
 
 - `http://127.0.0.1:3001/library/`
 
+## What to Edit for Common Tasks
+
+| Task | Start here |
+| --- | --- |
+| Update docs content | matching file under `docs/` |
+| Add or update a blog post | matching file under `blog/` |
+| Change homepage content | `src/pages/index.js` |
+| Change homepage feature blocks | `src/components/HomepageFeatures/` |
+| Change site-wide styles | `src/css/custom.css` |
+| Change navbar/footer/metadata | `docusaurus.config.js` |
+| Change docs sidebar behavior | `sidebars.js` |
+
+## Generated and Local-Only Directories
+
+These paths are usually generated locally and should not be treated as hand-edited source unless the task explicitly targets them:
+
+- `.docusaurus/`
+- `build/`
+- `node_modules/`
+- `static/img/screenshots/`
+
 ## Common Troubleshooting
 
 - `npm run start` fails at repo root: run commands from `docs/`, not the repository root.
 - `Something is already running on port 3000`: use `--port 3001` or stop the process on `3000`.
 - New blog image/content not showing: rebuild with `npm run build`, then run `npm run serve`, and hard refresh your browser.
+- Broken links after changing filenames or slugs: review `docusaurus.config.js`, sidebar structure, and internal Markdown links.


### PR DESCRIPTION
## Summary
- add a repo-level README for hushline-docs so contributors and agents can understand the repo quickly
- add a repo-level AGENTS.md with guidance on repo purpose, structure, local commands, and generated paths
- expand docs/README.md with a clearer Docusaurus directory map and common task entry points

## Why
The repo did not have a root README or AGENTS file, and the existing docs/README.md only covered basic local startup. This makes it harder for agents and new contributors to tell what is source, what is generated, and where to start for common tasks.

## Validation
- attempted npm run build from docs/, but it did not return a final status through the current tool window

## Manual Testing
- not applicable; documentation-only change

## Notes
- this PR intentionally excludes unrelated in-progress doc content edits and the large screenshot worktree changes already present locally