### PR TITLE
Add launchd wrapper for weekly docs article bot

### DIFF
--- a/deploy/launchd/com.hushline.docs.weekly-article.plist
+++ b/deploy/launchd/com.hushline.docs.weekly-article.plist
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.hushline.docs.weekly-article</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__REPO_DIR__/scripts/run_weekly_article_launchd.sh</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__REPO_DIR__</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>CODEX_HOME</key>
+    <string>__HOME_DIR__/.codex</string>
+    <key>GH_CONFIG_DIR</key>
+    <string>__HOME_DIR__/.config/gh</string>
+    <key>HOME</key>
+    <string>__HOME_DIR__</string>
+    <key>HUSHLINE_DOCS_BUILD_DIR</key>
+    <string>__REPO_DIR__/docs/build</string>
+    <key>HUSHLINE_DOCS_BOT_GIT_SIGNING_KEY</key>
+    <string>__BOT_SIGNING_KEY_PATH__</string>
+    <key>HUSHLINE_DOCS_ENV_FILE</key>
+    <string>__REPO_DIR__/.env.launchd</string>
+    <key>HUSHLINE_DOCS_LAUNCHD_PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>HUSHLINE_DOCS_REPO_DIR</key>
+    <string>__REPO_DIR__</string>
+    <key>HUSHLINE_WEBSITE_LIBRARY_DIR</key>
+    <string>__WEBSITE_REPO_DIR__/src/library</string>
+    <key>HUSHLINE_WEBSITE_REPO_DIR</key>
+    <string>__WEBSITE_REPO_DIR__</string>
+    <key>NPM_CONFIG_CACHE</key>
+    <string>__HOME_DIR__/.npm</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>XDG_CACHE_HOME</key>
+    <string>__HOME_DIR__/.cache</string>
+    <key>XDG_CONFIG_HOME</key>
+    <string>__HOME_DIR__/.config</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Weekday</key>
+    <integer>3</integer>
+    <key>Hour</key>
+    <integer>8</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>__REPO_DIR__/logs/weekly-article.stdout.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>__REPO_DIR__/logs/weekly-article.stderr.log</string>
+</dict>
+</plist>

--- a/scripts/run_weekly_article_launchd.sh
+++ b/scripts/run_weekly_article_launchd.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
-DEFAULT_WEBSITE_REPO_DIR="$(CDPATH= cd -- "$REPO_DIR/../hushline-website" && pwd)"
+DEFAULT_WEBSITE_REPO_DIR="$REPO_DIR/../hushline-website"
 LOCK_DIR="$REPO_DIR/.tmp/weekly-article.lock"
 ENV_FILE="${HUSHLINE_DOCS_ENV_FILE:-$REPO_DIR/.env.launchd}"
 
@@ -72,4 +72,4 @@ else
 fi
 
 cd "$HUSHLINE_DOCS_REPO_DIR"
-exec ./scripts/agent_weekly_article_runner.sh "$@"
+./scripts/agent_weekly_article_runner.sh "$@"

--- a/scripts/run_weekly_article_launchd.sh
+++ b/scripts/run_weekly_article_launchd.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+DEFAULT_WEBSITE_REPO_DIR="$(CDPATH= cd -- "$REPO_DIR/../hushline-website" && pwd)"
+LOCK_DIR="$REPO_DIR/.tmp/weekly-article.lock"
+ENV_FILE="${HUSHLINE_DOCS_ENV_FILE:-$REPO_DIR/.env.launchd}"
+
+export HOME="${HOME:-/Users/scidsg}"
+export PATH="${HUSHLINE_DOCS_LAUNCHD_PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+export GH_CONFIG_DIR="${GH_CONFIG_DIR:-$HOME/.config/gh}"
+export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export HUSHLINE_DOCS_REPO_DIR="${HUSHLINE_DOCS_REPO_DIR:-$REPO_DIR}"
+export HUSHLINE_WEBSITE_REPO_DIR="${HUSHLINE_WEBSITE_REPO_DIR:-$DEFAULT_WEBSITE_REPO_DIR}"
+export HUSHLINE_DOCS_BUILD_DIR="${HUSHLINE_DOCS_BUILD_DIR:-$HUSHLINE_DOCS_REPO_DIR/docs/build}"
+export HUSHLINE_WEBSITE_LIBRARY_DIR="${HUSHLINE_WEBSITE_LIBRARY_DIR:-$HUSHLINE_WEBSITE_REPO_DIR/src/library}"
+
+if [[ -z "${SSH_AUTH_SOCK:-}" ]]; then
+  SSH_AUTH_SOCK="$(launchctl getenv SSH_AUTH_SOCK 2>/dev/null || true)"
+  if [[ -n "$SSH_AUTH_SOCK" ]]; then
+    export SSH_AUTH_SOCK
+  fi
+fi
+
+cleanup() {
+  rmdir "$LOCK_DIR" >/dev/null 2>&1 || true
+}
+
+runner_status() {
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')" "$*"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'Missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "$REPO_DIR/.tmp" "$REPO_DIR/logs"
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  printf 'Weekly docs article runner is already running. Exiting.\n' >&2
+  exit 0
+fi
+trap cleanup EXIT
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
+require_cmd bash
+require_cmd codex
+require_cmd git
+require_cmd node
+require_cmd npm
+
+runner_status "Starting weekly docs article launchd wrapper."
+runner_status "Using docs repo: $HUSHLINE_DOCS_REPO_DIR"
+runner_status "Using website repo: $HUSHLINE_WEBSITE_REPO_DIR"
+if [[ -n "${SSH_AUTH_SOCK:-}" ]]; then
+  runner_status "Using SSH_AUTH_SOCK: $SSH_AUTH_SOCK"
+else
+  runner_status "SSH_AUTH_SOCK is not set."
+fi
+
+cd "$HUSHLINE_DOCS_REPO_DIR"
+exec ./scripts/agent_weekly_article_runner.sh "$@"


### PR DESCRIPTION
## Summary
- add a checked-in launchd wrapper for the weekly docs article runner
- add a checked-in LaunchAgent plist template for the Wednesday 8:00 AM schedule
- keep the launchd environment explicit for PATH, repo locations, logs, Codex, npm, and signing

## Validation
- ran `bash -n scripts/run_weekly_article_launchd.sh`
- ran `plutil -lint deploy/launchd/com.hushline.docs.weekly-article.plist`
- ran `./scripts/run_weekly_article_launchd.sh --dry-run --date 2026-04-01`

## Notes
- machine-local installation, launchctl loading, and the dedicated non-interactive signing key were applied on the server and are not part of this PR
- GitHub signing-key registration for Verified badges is still manual because the current `gh` token lacks `admin:ssh_signing_key` scope