### PR TITLE
Fix weekly article launchd runner

### DIFF
--- a/deploy/launchd/com.hushline.docs.weekly-article.plist
+++ b/deploy/launchd/com.hushline.docs.weekly-article.plist
@@ -16,7 +16,7 @@
   <key>EnvironmentVariables</key>
   <dict>
     <key>CODEX_HOME</key>
-    <string>__HOME_DIR__/.codex</string>
+    <string>__HOME_DIR__/.codex-hushline-agent-002</string>
     <key>GH_CONFIG_DIR</key>
     <string>__HOME_DIR__/.config/gh</string>
     <key>HOME</key>
@@ -31,6 +31,8 @@
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     <key>HUSHLINE_DOCS_REPO_DIR</key>
     <string>__REPO_DIR__</string>
+    <key>HUSHLINE_DOCS_WEEKLY_ALLOW_TOPIC_REUSE</key>
+    <string>1</string>
     <key>HUSHLINE_WEBSITE_LIBRARY_DIR</key>
     <string>__WEBSITE_REPO_DIR__/src/library</string>
     <key>HUSHLINE_WEBSITE_REPO_DIR</key>

--- a/scripts/agent_weekly_article_runner.sh
+++ b/scripts/agent_weekly_article_runner.sh
@@ -567,6 +567,7 @@ build_prompt() {
   local supporting_docs="$9"
   local feature_key="${10}"
   local core_user_key="${11}"
+  local last_used_at="${12:-}"
 
   {
     cat <<EOF2
@@ -600,6 +601,11 @@ Article requirements:
 17) Section headings must be specific to the article's subject. Do not use canned headings like "The Real-World Scenario", "Why This Matters", "The Practical Takeaway", or "Conclusion".
 18) Do not include meta commentary about following instructions in your final summary.
 EOF2
+    if [[ -n "$last_used_at" ]]; then
+      cat <<EOF2
+19) This topic was last used on $last_used_at. Treat the title seed as directional only: choose a fresh final title, scenario framing, and article structure so this post is not a duplicate of the previous article.
+EOF2
+    fi
   } > "$PROMPT_FILE"
 }
 
@@ -780,6 +786,7 @@ main() {
   local article_slug=""
   local feature_key=""
   local core_user_key=""
+  local last_used_at=""
 
   topic_id="$(json_field "$SELECTION_FILE" "topic.id")"
   title_seed="$(json_field "$SELECTION_FILE" "topic.title_seed")"
@@ -792,11 +799,16 @@ main() {
   article_slug="$(json_field "$SELECTION_FILE" "articleSlug")"
   feature_key="$(json_field "$SELECTION_FILE" "topic.feature_key")"
   core_user_key="$(json_field "$SELECTION_FILE" "topic.core_user_key")"
+  last_used_at="$(json_field "$SELECTION_FILE" "lastUsedAt")"
 
   runner_status "Selected weekly article topic: $topic_id"
   runner_status "Planned article path: $article_path"
-  assert_blog_title_is_unique "$title_seed" "$article_path"
-  assert_blog_topic_is_unique "$topic_id" "$article_path"
+  if [[ -z "$last_used_at" ]]; then
+    assert_blog_title_is_unique "$title_seed" "$article_path"
+    assert_blog_topic_is_unique "$topic_id" "$article_path"
+  else
+    runner_status "Reusing previously published topic $topic_id from $last_used_at."
+  fi
 
   build_prompt \
     "$article_path" \
@@ -809,7 +821,8 @@ main() {
     "$prompt_angle" \
     "$supporting_docs" \
     "$feature_key" \
-    "$core_user_key"
+    "$core_user_key" \
+    "$last_used_at"
 
   run_codex_from_prompt
   assert_generated_article_author "$REPO_DIR/$article_path"

--- a/scripts/run_weekly_article_launchd.sh
+++ b/scripts/run_weekly_article_launchd.sh
@@ -9,7 +9,7 @@ ENV_FILE="${HUSHLINE_DOCS_ENV_FILE:-$REPO_DIR/.env.launchd}"
 
 export HOME="${HOME:-/Users/scidsg}"
 export PATH="${HUSHLINE_DOCS_LAUNCHD_PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
-export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex-hushline-agent-002}"
 export GH_CONFIG_DIR="${GH_CONFIG_DIR:-$HOME/.config/gh}"
 export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm}"
 export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"

--- a/scripts/select_weekly_article_topic.test.mjs
+++ b/scripts/select_weekly_article_topic.test.mjs
@@ -55,7 +55,7 @@ test('selectTopic prefers topics that have never been used', () => {
   assert.equal(selectTopic({ topics, usage, forcedTopicId: '' }).id, 'topic-c');
 });
 
-test('selectTopic falls back to least recently used topic when all have been used', () => {
+test('selectTopic blocks reuse by default when all topics have been used', () => {
   const topics = [
     { id: 'topic-a' },
     { id: 'topic-b' },
@@ -67,7 +67,25 @@ test('selectTopic falls back to least recently used topic when all have been use
     ['topic-c', '2026-04-01'],
   ]);
 
-  assert.equal(selectTopic({ topics, usage, forcedTopicId: '' }).id, 'topic-b');
+  assert.throws(
+    () => selectTopic({ topics, usage, forcedTopicId: '' }),
+    /All weekly article topics in the catalog have already been used/,
+  );
+});
+
+test('selectTopic falls back to least recently used topic when reuse is enabled', () => {
+  const topics = [
+    { id: 'topic-a' },
+    { id: 'topic-b' },
+    { id: 'topic-c' },
+  ];
+  const usage = new Map([
+    ['topic-a', '2026-03-01'],
+    ['topic-b', '2026-02-01'],
+    ['topic-c', '2026-04-01'],
+  ]);
+
+  assert.equal(selectTopic({ topics, usage, forcedTopicId: '', allowReuse: true }).id, 'topic-b');
 });
 
 test('buildSelection returns the final article path and slug', () => {


### PR DESCRIPTION
## What changed

- Point the weekly article launchd wrapper and plist template at `/Users/scidsg/.codex-hushline-agent-002` instead of the default Codex home.
- Enable `HUSHLINE_DOCS_WEEKLY_ALLOW_TOPIC_REUSE=1` in the weekly article LaunchAgent template.
- Make topic reuse work end-to-end by skipping duplicate title/topic preflight when a reused topic is selected and telling Codex to write a fresh angle.
- Update topic-selection tests to cover the default exhausted-catalog block and explicit reuse fallback.

## Why

The installed weekly article LaunchAgent had never completed because the launchd stdout/stderr directory was missing locally, the service was configured with the wrong Codex workspace, and the weekly topic catalog is exhausted. Dry-run failed with: `All weekly article topics in the catalog have already been used`.

The local installed LaunchAgent has also been updated and reloaded outside this commit:

- `CODEX_HOME=/Users/scidsg/.codex-hushline-agent-002`
- `HUSHLINE_DOCS_WEEKLY_ALLOW_TOPIC_REUSE=1`
- `/Users/scidsg/hushline-docs/logs/` and `.tmp/` created

## Validation

- `bash -n scripts/agent_weekly_article_runner.sh scripts/run_weekly_article_launchd.sh`
- `node --test scripts/select_weekly_article_topic.test.mjs`
- `plutil -lint deploy/launchd/com.hushline.docs.weekly-article.plist`
- `git diff --check`
- `HUSHLINE_DOCS_WEEKLY_ALLOW_TOPIC_REUSE=1 /Users/scidsg/hushline-docs/scripts/run_weekly_article_launchd.sh --dry-run`

## Manual testing

Not applicable for the article generation itself in this PR; the dry-run verifies launch wrapper startup and topic selection without resetting repos, invoking Codex, building docs, or publishing.

## Risks and follow-up

- The next scheduled full run will hard-reset and force-push the configured docs and website repos by design.
- GitHub reported existing default-branch Dependabot vulnerabilities during push; this PR does not change dependencies.