### PR TITLE
Update ws dependency

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -18036,9 +18036,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -18300,9 +18300,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"


### PR DESCRIPTION
## What changed
- Updated the transitive `ws` dependency used by `webpack-dev-server` from `8.20.0` to `8.21.0` in `docs/package-lock.json`.
- This addresses Dependabot alert #46 / GHSA-58qx-3vcg-4xpx, whose patched version floor is `8.20.1`.

## Why it changed
`ws@8.20.0` is affected by an uninitialized memory disclosure advisory. The docs site uses it through Docusaurus' development server dependency chain.

## Validation
- `npm ls ws --all`
- `npm audit --omit=dev --json` confirmed the separate `uuid` alert remains, but `ws` is no longer listed.
- `npm run build`

## Manual testing
- Not separately run; this is a lockfile-only transitive dependency update for the Docusaurus build/dev dependency tree.

## Known risks / follow-ups
- Dependabot alert #44 for `uuid` is intentionally handled in a separate PR.
