### PR TITLE
Override uuid dependency

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -17705,12 +17705,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,10 @@
   },
   "overrides": {
     "brace-expansion": "^5.0.6",
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "sockjs": {
+      "uuid": "11.1.1"
+    }
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## What changed
- Added a scoped npm override so `sockjs` uses `uuid@11.1.1`.
- Updated `docs/package-lock.json` to resolve the vulnerable transitive `uuid@8.3.2` to the patched version.
- This addresses Dependabot alert #44 / GHSA-w5hq-g745-h8pq.

## Why it changed
`uuid` versions before `11.1.1` are affected by a missing buffer bounds check advisory. In this project, the vulnerable package is pulled through the Docusaurus development server chain: `@docusaurus/core -> webpack-dev-server -> sockjs -> uuid`.

## Compatibility notes
- `sockjs` imports `require('uuid').v4`; that API still resolves under `uuid@11.1.1`.
- Verified `require('sockjs')` still loads.

## Validation
- `npm ls uuid --all`
- `node -e "const uuid = require('uuid'); console.log(typeof uuid.v4, uuid.v4().length)"`
- `node -e "require('sockjs'); console.log('sockjs loaded')"`
- `npm audit --omit=dev --json` confirmed the separate `ws` alert remains, but `uuid` is no longer listed.
- `npm run build`

## Manual testing
- Not separately run; this is a transitive dependency override for the Docusaurus build/dev dependency tree.

## Known risks / follow-ups
- Dependabot alert #46 for `ws` is intentionally handled in separate PR #59.
