### PR TITLE
Use website screenshots in weekly docs build

### DIFF
--- a/docs/AGENT_WEEKLY_ARTICLE_RUNNER.md
+++ b/docs/AGENT_WEEKLY_ARTICLE_RUNNER.md
@@ -44,10 +44,11 @@ The selector script [`scripts/select_weekly_article_topic.mjs`](../scripts/selec
    - `npm run build`
 8. Build a social-share archive for the article.
    - Generate the text-only social copy from article context via Codex and validate the returned question/body format before writing the archive.
-9. Delete the contents of `hushline-website/src/library`.
-10. Copy the new contents of `docs/build/` into `hushline-website/src/library`.
-11. Commit and force-push directly to the configured base branches in both repositories. No PR is created.
-12. When weekly social sharing is enabled, install the rendered article archive into `hushline-social/previous-posts/<date-or-date-suffix>/` and publish it through the existing LinkedIn publisher.
+9. Replace `docs/build/img/screenshots/` with the curated current screenshot tree from `hushline-website/src/assets/img/screenshots/current`.
+10. Delete the contents of `hushline-website/src/library`.
+11. Copy the prepared contents of `docs/build/` into `hushline-website/src/library`.
+12. Commit and force-push directly to the configured base branches in both repositories. No PR is created.
+13. When weekly social sharing is enabled, install the rendered article archive into `hushline-social/previous-posts/<date-or-date-suffix>/` and publish it through the existing LinkedIn publisher.
 
 The rendered article-share copy should:
 
@@ -143,6 +144,8 @@ The default publish layout assumes sibling checkouts:
 - `HUSHLINE_WEBSITE_REPO_SLUG` (default `scidsg/hushline-website`)
 - `HUSHLINE_WEBSITE_BASE_BRANCH` (default `main`)
 - `HUSHLINE_WEBSITE_LIBRARY_DIR` (default `src/library` inside `HUSHLINE_WEBSITE_REPO_DIR`)
+- `HUSHLINE_WEBSITE_CURRENT_SCREENSHOTS_DIR` (default `src/assets/img/screenshots/current` inside `HUSHLINE_WEBSITE_REPO_DIR`)
+- `HUSHLINE_DOCS_BUILD_SCREENSHOTS_DIR` (default `img/screenshots` inside `HUSHLINE_DOCS_BUILD_DIR`)
 - `HUSHLINE_DOCS_SITE_BASE_URL` (default `https://hushline.app/library`)
 - `HUSHLINE_DOCS_WEEKLY_SOCIAL_ENABLED` (default `1`)
 - `HUSHLINE_DOCS_WEEKLY_SOCIAL_PUBLISH` (default `1`)
@@ -158,6 +161,6 @@ The default publish layout assumes sibling checkouts:
 - This runner is intentionally lighter than the Hush Line app runners because `hushline-docs` has no Docker runtime or app test matrix to bootstrap.
 - It assumes both `hushline-docs` and `hushline-website` are dedicated automation checkouts because it hard-resets both working trees to their configured base branches.
 - If weekly social sharing is enabled, point `HUSHLINE_SOCIAL_REPO_DIR` at a dedicated automation checkout of `hushline-social` as well, because the runner refreshes that checkout before writing the new article-share archive and triggering LinkedIn publication.
-- The publish step is destructive by design: it removes the existing contents of `src/library` only after `npm run build` succeeds, then copies the fresh build output into place.
+- The publish step is destructive by design: it removes the existing contents of `src/library` only after `npm run build` succeeds, replaces the build's screenshot assets with the website repo's curated current screenshots, then copies the fresh build output into place.
 - `--dry-run` is safe for local inspection because it only prints the selected topic JSON and exits before any git reset, signing setup, or publish work.
 - The scheduled launchd wrapper is intended to run from a checkout on `main`. Running the weekly runner from stale feature branches is unsupported because older script snapshots can bypass newer publish and LinkedIn-share safeguards.

--- a/scripts/agent_weekly_article_runner.sh
+++ b/scripts/agent_weekly_article_runner.sh
@@ -54,7 +54,9 @@ WEBSITE_REPO_DIR="${HUSHLINE_WEBSITE_REPO_DIR:-$DEFAULT_REPO_PARENT_DIR/hushline
 WEBSITE_REPO_SLUG="${HUSHLINE_WEBSITE_REPO_SLUG:-scidsg/hushline-website}"
 WEBSITE_BASE_BRANCH="${HUSHLINE_WEBSITE_BASE_BRANCH:-main}"
 WEBSITE_LIBRARY_DIR="${HUSHLINE_WEBSITE_LIBRARY_DIR:-$WEBSITE_REPO_DIR/src/library}"
+WEBSITE_CURRENT_SCREENSHOTS_DIR="${HUSHLINE_WEBSITE_CURRENT_SCREENSHOTS_DIR:-$WEBSITE_REPO_DIR/src/assets/img/screenshots/current}"
 DOCS_BUILD_DIR="${HUSHLINE_DOCS_BUILD_DIR:-$REPO_DIR/docs/build}"
+DOCS_BUILD_SCREENSHOTS_DIR="${HUSHLINE_DOCS_BUILD_SCREENSHOTS_DIR:-$DOCS_BUILD_DIR/img/screenshots}"
 ALLOW_FUTURE_PUBLICATION_DATE="${HUSHLINE_DOCS_ALLOW_FUTURE_PUBLICATION_DATE:-0}"
 SITE_BASE_URL="${HUSHLINE_DOCS_SITE_BASE_URL:-https://hushline.app/library}"
 SOCIAL_ENABLED="${HUSHLINE_DOCS_WEEKLY_SOCIAL_ENABLED:-1}"
@@ -336,6 +338,18 @@ sync_build_to_website() {
   runner_status "Replacing $WEBSITE_REPO_SLUG:$target_dir with the latest docs build."
   find "$target_dir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
   cp -a "$build_dir"/. "$target_dir"/
+}
+
+sync_build_screenshots_from_website() {
+  local source_dir="$1"
+  local target_dir="$2"
+
+  assert_directory_exists "$source_dir"
+
+  runner_status "Replacing docs build screenshots with curated website screenshots from $source_dir."
+  rm -rf "$target_dir"
+  mkdir -p "$target_dir"
+  cp -a "$source_dir"/. "$target_dir"/
 }
 
 resolve_next_archive_key() {
@@ -839,6 +853,7 @@ main() {
     render_social_handoff "$article_path" "$article_slug"
   fi
 
+  sync_build_screenshots_from_website "$WEBSITE_CURRENT_SCREENSHOTS_DIR" "$DOCS_BUILD_SCREENSHOTS_DIR"
   sync_build_to_website "$DOCS_BUILD_DIR" "$WEBSITE_LIBRARY_DIR"
 
   git -C "$REPO_DIR" add -A


### PR DESCRIPTION
## What changed
- The weekly article runner now replaces `docs/build/img/screenshots/` with the curated current screenshot tree from `hushline-website/src/assets/img/screenshots/current` before copying the build into `hushline-website/src/library`.
- Added environment overrides for the website current screenshot source and docs build screenshot target.
- Updated the runner documentation to describe the screenshot source and publish order.

## Why
The public site should publish docs artifacts with screenshots from `hushline-website`, not stale or locally generated files from `hushline-docs`. This keeps docs, blog/library pages, and public site assets aligned with the curated screenshot workflow.

## Validation
- `bash -n scripts/agent_weekly_article_runner.sh`
- `git diff --check`

## Manual testing
Not run. This clean PR worktree does not have `docs/node_modules`; the change is limited to shell publish behavior and its operations documentation.

## Known risks or follow-ups
Companion app workflow PR: https://github.com/scidsg/hushline/pull/2159. That PR updates screenshot capture and publish allowlisting so the QR/2FA screenshot referenced by docs remains captured with the existing masks.