### PR TITLE
Use shared Codex home for docs runner

### DIFF
--- a/deploy/launchd/com.hushline.docs.weekly-article.plist
+++ b/deploy/launchd/com.hushline.docs.weekly-article.plist
@@ -16,7 +16,7 @@
   <key>EnvironmentVariables</key>
   <dict>
     <key>CODEX_HOME</key>
-    <string>__HOME_DIR__/.codex-hushline-agent-002</string>
+    <string>__HOME_DIR__/.codex-hushline-agents</string>
     <key>GH_CONFIG_DIR</key>
     <string>__HOME_DIR__/.config/gh</string>
     <key>HOME</key>

--- a/docs/AGENT_WEEKLY_ARTICLE_RUNNER.md
+++ b/docs/AGENT_WEEKLY_ARTICLE_RUNNER.md
@@ -153,6 +153,7 @@ The default publish layout assumes sibling checkouts:
 - `HUSHLINE_SOCIAL_BASE_BRANCH` (default `main`)
 - `HUSHLINE_SOCIAL_ARCHIVE_ROOT` (default `previous-posts`)
 - `HUSHLINE_SOCIAL_ENV_FILE` (default `HUSHLINE_SOCIAL_REPO_DIR/.env.launchd`)
+- `CODEX_HOME` (default `~/.codex-hushline-agents` in the launchd wrapper)
 - `HUSHLINE_CODEX_MODEL` (default `gpt-5.4`)
 - `HUSHLINE_CODEX_REASONING_EFFORT` (default `high`)
 

--- a/scripts/run_weekly_article_launchd.sh
+++ b/scripts/run_weekly_article_launchd.sh
@@ -9,7 +9,7 @@ ENV_FILE="${HUSHLINE_DOCS_ENV_FILE:-$REPO_DIR/.env.launchd}"
 
 export HOME="${HOME:-/Users/scidsg}"
 export PATH="${HUSHLINE_DOCS_LAUNCHD_PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
-export CODEX_HOME="${CODEX_HOME:-$HOME/.codex-hushline-agent-002}"
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex-hushline-agents}"
 export GH_CONFIG_DIR="${GH_CONFIG_DIR:-$HOME/.config/gh}"
 export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm}"
 export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"


### PR DESCRIPTION
## What changed
- Updated the docs weekly article launchd wrapper fallback `CODEX_HOME` to `~/.codex-hushline-agents`.
- Updated the docs weekly article launchd plist template to use the same shared Codex home.
- Documented the launchd wrapper's shared `CODEX_HOME` default.

## Why
Hush Line moved from numbered agent workspaces to a single shared agents workspace. The docs weekly article runner is currently disabled locally, but if it is re-enabled later it should not recreate or depend on the retired `agent-002` Codex home.

## Validation
- `bash -n scripts/run_weekly_article_launchd.sh`
- `plutil -lint deploy/launchd/com.hushline.docs.weekly-article.plist`
- `git diff --check`
- `rg "agent-002|codex-hushline-agent" -n scripts deploy docs README.md AGENTS.md`

## Manual testing
Not applicable. The installed local docs weekly article LaunchAgent is disabled; this updates the wrapper/template for future re-enable/install paths.

## Known risks or follow-ups
No active launchd job needs to be reloaded for this change unless the disabled docs weekly article runner is re-enabled or reinstalled.