### PR TITLE
Use evergreen screenshot references

### DIFF
--- a/docs/docs/getting-started/account-setup.md
+++ b/docs/docs/getting-started/account-setup.md
@@ -12,13 +12,13 @@ Let's get you set up! Hush Line works best as a background service—once config
 
 In **Settings > Profile**, add a clear bio, extra links, or your Signal username to help your community.
 
-![Settings](/img/screenshots/current/newman/auth-newman-settings-profile-desktop-light-fold.png)
+![Settings](/img/screenshots/newman/auth-newman-settings-profile-desktop-light-fold.png)
 
 ## Step 2. Enable End-to-End Encryption
 
 Add an encryption key so you can receive messages securely. Let's start from **Settings > Encryption**:
 
-![Encryption settings wireframe](/img/screenshots/current/newman/auth-newman-settings-encryption-desktop-light-fold.png)
+![Encryption settings wireframe](/img/screenshots/newman/auth-newman-settings-encryption-desktop-light-fold.png)
 
 ### Option 2.1. Use with Proton Mail
 
@@ -32,7 +32,7 @@ Prefer Gmail or no email forwarding? Use [Mailvelope](https://mailvelope.com/en/
 
 Forward messages so you don’t have to log back in. For Proton Mail, use your new Proton email. For Gmail users with Mailvelope, click the red Mailvelope seal in your inbox and enter your key password.
 
-![Email](/img/screenshots/current/artvandelay/auth-artvandelay-settings-notifications-desktop-light-fold.png)
+![Email](/img/screenshots/artvandelay/auth-artvandelay-settings-notifications-desktop-light-fold.png)
 
 ---
 

--- a/docs/docs/getting-started/intro.md
+++ b/docs/docs/getting-started/intro.md
@@ -16,7 +16,7 @@ First, create your account. When complete you'll redirect to the login page.
 
 [👉 Register](https://tips.hushline.app/register)
 
-![Register and Login](/img/screenshots/current/guest/guest-register-desktop-light-fold.png)
+![Register and Login](/img/screenshots/guest/guest-register-desktop-light-fold.png)
 
 ---
 

--- a/docs/docs/getting-started/new-user-onboarding.md
+++ b/docs/docs/getting-started/new-user-onboarding.md
@@ -12,31 +12,31 @@ New user onboarding is a guided, four-step process that will result in a fully f
 
 Add a clear bio, extra links, or your Signal username to help your community.
 
-![Settings](/img/screenshots/current/newman/auth-newman-onboarding-profile-desktop-light-fold.png)
+![Settings](/img/screenshots/newman/auth-newman-onboarding-profile-desktop-light-fold.png)
 
 ## Step 2. Enable End-to-End Encryption
 
 Add an encryption key so you can receive messages securely:
 
-![Encryption settings wireframe](/img/screenshots/current/newman/auth-newman-onboarding-encryption-desktop-light-fold.png)
+![Encryption settings wireframe](/img/screenshots/newman/auth-newman-onboarding-encryption-desktop-light-fold.png)
 
 ## Step 3. Enable Message Forwarding
 
 Forward messages so you don’t have to log back in. If you imported a key from Proton in the previous step, you should use the same email address here.
 
-![Email](/img/screenshots/current/newman/auth-newman-onboarding-notifications-desktop-light-fold.png)
+![Email](/img/screenshots/newman/auth-newman-onboarding-notifications-desktop-light-fold.png)
 
 ## Step 4. Add Yourself to the User Directory
 
 Opt-in to the public user directory so whistleblowers can find your account.
 
-![Directory](/img/screenshots/current/newman/auth-newman-onboarding-directory-desktop-light-fold.png)
+![Directory](/img/screenshots/newman/auth-newman-onboarding-directory-desktop-light-fold.png)
 
 ## Skipping Onboarding
 
 If you skip onboarding, you can easily access it again using the **Account Setup** link in the header.
 
-![Empty Inbox](/img/screenshots/current/newman/auth-newman-inbox-desktop-light-fold.png)
+![Empty Inbox](/img/screenshots/newman/auth-newman-inbox-desktop-light-fold.png)
 
 ---
 

--- a/docs/docs/getting-started/secure-your-account.md
+++ b/docs/docs/getting-started/secure-your-account.md
@@ -8,13 +8,13 @@ title: Secure Your Account
 
 Enhance your security by enabling 2FA. In **Settings > Authentication > Two-Factor Authentication**, click **Enable 2FA**.
 
-![Enable 2FA](/img/screenshots/current/artvandelay/auth-artvandelay-settings-auth-desktop-light-fold.png)
+![Enable 2FA](/img/screenshots/artvandelay/auth-artvandelay-settings-auth-desktop-light-fold.png)
 
 ## Step 2. Scan the QR Code
 
 Download an authenticator app like Google Authenticator or Aegis, scan the QR code, and enter the generated six-digit code in the “2FA Code” field.
 
-![Scan QR](/img/screenshots/current/artvandelay/auth-artvandelay-enable-2fa-desktop-light-fold.png)
+![Scan QR](/img/screenshots/artvandelay/auth-artvandelay-enable-2fa-desktop-light-fold.png)
 
 ## Step 3. Log in Again
 

--- a/docs/docs/getting-started/share-your-tip-line.md
+++ b/docs/docs/getting-started/share-your-tip-line.md
@@ -8,7 +8,7 @@ sidebar_position: 5
 
 Opt-in to the public user directory in **Settings > Profile > Public User Directory** so whistleblowers can find your account.
 
-![Settings](/img/screenshots/current/artvandelay/auth-artvandelay-settings-profile-desktop-light-fold.png)
+![Settings](/img/screenshots/artvandelay/auth-artvandelay-settings-profile-desktop-light-fold.png)
 
 ## Step 2. Share Your Address Widely
 

--- a/docs/docs/using-your-tip-line/account-verification.md
+++ b/docs/docs/using-your-tip-line/account-verification.md
@@ -8,13 +8,13 @@ sidebar_position: 8
 
 In **Settings > Profile**, update your Display Name for authenticity. (Changing it later will remove verified status.)
 
-![Settings](/img/screenshots/current/artvandelay/auth-artvandelay-settings-profile-desktop-light-fold.png)
+![Settings](/img/screenshots/artvandelay/auth-artvandelay-settings-profile-desktop-light-fold.png)
 
 ## Step 2. Include Additional URLs
 
 Add your LinkedIn, website, or other professional profiles in your bio’s extra fields for multi-channel verification.
 
-![Extra URL fields](/img/screenshots/current/artvandelay/auth-artvandelay-settings-profile-desktop-light-window-02.png)
+![Extra URL fields](/img/screenshots/artvandelay/auth-artvandelay-settings-profile-desktop-light-window-02.png)
 
 ## Step 3. Contact Us
 
@@ -22,4 +22,4 @@ When ready, contact us to begin verification. Businesses should have authorized 
 
 [Verify Your Account](https://tips.hushline.app/to/admin)
 
-![Message verification](/img/screenshots/current/guest/guest-profile-admin-desktop-light-fold.png)
+![Message verification](/img/screenshots/guest/guest-profile-admin-desktop-light-fold.png)

--- a/docs/docs/using-your-tip-line/dark-mode.md
+++ b/docs/docs/using-your-tip-line/dark-mode.md
@@ -6,4 +6,4 @@ sidebar_position: 10
 
 Hush Line's dark mode is automatic based on your operating system's settings. If you choose to see dark mode in the evening, Hush Line inherits it so you don't have to manually change any other settings.
 
-![Dark Mode](/img/screenshots/current/guest/guest-directory-verified-desktop-dark-fold.png)
+![Dark Mode](/img/screenshots/guest/guest-directory-verified-desktop-dark-fold.png)

--- a/docs/docs/using-your-tip-line/data-download.md
+++ b/docs/docs/using-your-tip-line/data-download.md
@@ -10,7 +10,7 @@ Hush Line provides a self-serve mechanism to download a complete copy of your ac
 
 Navigate to <code>Settings > Advanced</code> to find the **Download My Data** section.
 
-![Advanced Settings](/img/screenshots/current/artvandelay/auth-artvandelay-settings-advanced-desktop-light-fold.png)
+![Advanced Settings](/img/screenshots/artvandelay/auth-artvandelay-settings-advanced-desktop-light-fold.png)
 
 ## What Is Included
 

--- a/docs/docs/using-your-tip-line/inbox.md
+++ b/docs/docs/using-your-tip-line/inbox.md
@@ -6,10 +6,10 @@ sidebar_position: 5
 
 ## Step 1. Inbox on the Desktop
 
-![Desktop Inbox](/img/screenshots/current/newman/auth-newman-inbox-desktop-light-fold.png)
+![Desktop Inbox](/img/screenshots/newman/auth-newman-inbox-desktop-light-fold.png)
 
 When you start receiving Hush Line messages, your Inbox will help keep you organized. When you change the status of a message, you'll be able to quickly filter to see all messages with those statuses.
 
 When using a desktop or laptop computer your inbox tabs will display on the left side of the interface.
 
-![Desktop Inbox](/img/screenshots/current/artvandelay/auth-artvandelay-inbox-desktop-light-fold.png)
+![Desktop Inbox](/img/screenshots/artvandelay/auth-artvandelay-inbox-desktop-light-fold.png)

--- a/docs/docs/using-your-tip-line/message-replies.md
+++ b/docs/docs/using-your-tip-line/message-replies.md
@@ -10,7 +10,7 @@ sidebar_position: 7
 
 Customize automatic responses when a tip is received (e.g., “✅ Accepted” or “⛔️ Declined”) to include additional contact details.
 
-![Custom replies example](/img/screenshots/current/artvandelay/auth-artvandelay-settings-replies-desktop-light-fold.png)
+![Custom replies example](/img/screenshots/artvandelay/auth-artvandelay-settings-replies-desktop-light-fold.png)
 
 ## Step 2. A Good Accept Message
 
@@ -30,4 +30,4 @@ When someone submits a message to you they'll receive a unique URL only known to
 them. When you update the status of a message in your inbox, the message on this
 page will update.
 
-![Status dropdown options](/img/screenshots/current/guest/guest-message-status-desktop-light-fold.png)
+![Status dropdown options](/img/screenshots/guest/guest-message-status-desktop-light-fold.png)

--- a/docs/docs/using-your-tip-line/tools/email-validation.md
+++ b/docs/docs/using-your-tip-line/tools/email-validation.md
@@ -10,7 +10,7 @@ Route: `/email-headers`
 
 Paste raw email headers and Hush Line analyzes available authentication artifacts to help determine whether an email appears to originate from the stated sender.
 
-![Email Validation](/img/screenshots/current/admin/auth-admin-tools-email-validation-desktop-light-fold.png)
+![Email Validation](/img/screenshots/admin/auth-admin-tools-email-validation-desktop-light-fold.png)
 
 ## What It Checks
 
@@ -34,15 +34,15 @@ Each section includes a `Summary` block that explains how to interpret the findi
 
 ### Authentic Email Example
 
-![Successful Email Validation](/img/screenshots/current/admin/auth-admin-tools-email-validation-status-valid-desktop-light-fold.png)
+![Successful Email Validation](/img/screenshots/admin/auth-admin-tools-email-validation-status-valid-desktop-light-fold.png)
 
 ### Inauthentic Email Example
 
-![Inauthentic Email](/img/screenshots/current/admin/auth-admin-tools-email-validation-status-inauthentic-desktop-light-fold.png)
+![Inauthentic Email](/img/screenshots/admin/auth-admin-tools-email-validation-status-inauthentic-desktop-light-fold.png)
 
 ### Forged Email Example
 
-![Forged Email](/img/screenshots/current/admin/auth-admin-tools-email-validation-status-forged-desktop-light-fold.png)
+![Forged Email](/img/screenshots/admin/auth-admin-tools-email-validation-status-forged-desktop-light-fold.png)
 
 ## Report Download
 

--- a/docs/docs/using-your-tip-line/tools/vision-assistant.md
+++ b/docs/docs/using-your-tip-line/tools/vision-assistant.md
@@ -10,7 +10,7 @@ Route: `/vision`
 
 Vision Assistant is a browser-based OCR tool that extracts searchable text from uploaded images.
 
-![Vision Assistant](/img/screenshots/current/admin/auth-admin-tools-vision-assistant-desktop-light-fold.png)
+![Vision Assistant](/img/screenshots/admin/auth-admin-tools-vision-assistant-desktop-light-fold.png)
 
 ## How It Works
 


### PR DESCRIPTION
## What changed
- Updated docs screenshot links from /img/screenshots/current/... to the evergreen /img/screenshots/... tree.
- Refreshed the evergreen screenshot assets from hushline-website/src/assets/img/screenshots/current.
- Removed the stale docs/static/img/screenshots/current alias tree so docs do not keep resolving old screenshot copies.
- Covered onboarding, account setup, 2FA, inbox, verification, replies, dark mode, data download, and tools docs.

## Why
The docs were still displaying old screenshots because the docs source pointed at stale current aliases, and the evergreen docs screenshot files had not been refreshed from the website current screenshot source.

## Validation
- npm run build
- Confirmed no docs/blog/source references remain for /img/screenshots/current/.
- Confirmed the 2FA docs source image matches the website current masked QR screenshot byte-for-byte.
- Confirmed the generated 2FA asset is the masked 32,672-byte screenshot.

## Manual testing
- Not separately served locally; production Docusaurus build completed successfully.