### PR TITLE
Add AI IPO wealth donor article

### DIFF
--- a/docs/blog/2026-06-11-ai-ipo-wealth-public-service/index.md
+++ b/docs/blog/2026-06-11-ai-ipo-wealth-public-service/index.md
@@ -1,0 +1,101 @@
+---
+slug: ai-ipo-wealth-public-service
+title: "If AI Makes You Rich, San Francisco Still Needs You"
+subtitle: "A direct appeal to the people about to become very wealthy from the AI boom: do not confuse vesting with having done your part."
+authors: [gsorrentino]
+tags: [hushline, whistleblowing]
+---
+
+San Francisco is about to watch another wave of private paper wealth become public money. SpaceX is preparing for a historic listing, Anthropic and OpenAI have reportedly moved toward IPOs, and the Bay Area housing market is already reacting as if the checks have cleared. [The Guardian reported today](https://www.theguardian.com/us-news/2026/jun/11/ai-wealth-boom-san-francisco-home-prices) that AI wealth is helping push San Francisco home prices higher, with OpenAI and Anthropic employees in the city and SpaceX wealth in the broader California orbit all part of the same speculative weather system. [Axios reported this week](https://www.axios.com/2026/06/08/openai-ipo) that OpenAI had confidentially filed draft IPO paperwork, following Anthropic's reported filing and just ahead of SpaceX's expected public debut.
+
+This is not a neutral event. It is a civic test.
+
+<!-- truncate -->
+
+If you work at one of these companies and your equity turns into life-changing money, this article is for you. Not your CEO. Not your comms team. Not the policy staff who will write the correct LinkedIn post about community investment. You.
+
+Because the city may not see that money unless you decide it should.
+
+## The Taxes That Could Have Helped Did Not Survive
+
+San Francisco has tried, more than once, to turn tech windfalls into public revenue.
+
+In 2019, officials floated what was widely described as an [IPO tax](https://www.axios.com/2019/05/09/san-francisco-proposes-ipo-tax-uber-lyft): a higher tax on stock-based compensation, timed around the Uber and Lyft IPO era. The idea was blunt but understandable. If a city helps produce enormous private wealth while its residents are being priced out, some of that wealth should help repair the city. The measure was delayed after criticism over vague language and confusion about what exactly it covered and how proceeds would be used, and the durable public-revenue pipe never arrived.
+
+This week, another attempt failed. Proposition D, the [Overpaid CEO Act](https://www.sfchronicle.com/sf/article/s-f-overpaid-ceo-act-fails-setback-for-unions-22293399.php), would have raised taxes on large companies whose top executives earn far more than their workers. The Chronicle reported that voters rejected it, even though supporters argued it could have brought in hundreds of millions of dollars a year for city services.
+
+The taxes could have helped. They were imperfect, contested, politically vulnerable, and now they are not coming to save anyone.
+
+That leaves a harder truth: if you are about to become rich because of San Francisco's AI economy, and you want this city to be less brutal, less hollowed out, less obviously divided between people with liquidity and people with nowhere to go, you cannot outsource your conscience to a ballot measure that lost.
+
+## Look Around Before You Cash Out
+
+Walk through Union Square. Walk through the Tenderloin. Walk through Civic Center. Do not do it as a tourist, a founder, a buyer, a board observer, or someone narrating urban decline for a podcast. Do it as a neighbor.
+
+Look at what it means to share a city with people who sleep outside while private valuations race toward twelve zeros. Look at what it means when the people building the next infrastructure layer of the internet can spend more on a down payment than many families will earn in decades. Look at what it means when a public hospital, a shelter provider, a legal aid clinic, an investigative newsroom, or a small open-source project has to beg for scraps while another employee tender offer quietly creates a few dozen new multimillionaires.
+
+There are no rules against hoarding wealth while your neighbors suffer. That is the problem. The law will let you keep far more than you need. Your company will celebrate your success. Your peers may tell you that you earned it, that you were early, that you took the risk, that markets reward value.
+
+Some of that may even be true.
+
+It is also incomplete.
+
+Your wealth is being created in a city with public transit, public hospitals, public schools, public defenders, public records, public universities, public roads, public courts, public workers, and decades of cultural work you did not build. It is being created in an ecosystem full of open-source software written by people who were not compensated like you. It is being created on top of public research, public tolerance for disruption, and public patience with companies that move fast and externalize the mess.
+
+If the city will not collect enough of that upside through taxes, then the people receiving the upside have a moral obligation to move money, time, and talent back into the public interest.
+
+## Vesting Is Not A Life Mission
+
+Here is the tough-love part: once you vest, you should seriously consider leaving.
+
+Not everyone. Not immediately. Not recklessly. But if your financial life is secure and you are still optimizing for another grant, another refresh, another internal ladder, another small increase in a number that has already crossed into "enough," you need to ask what you are doing.
+
+The city needs engineers, designers, security people, operators, finance people, comms people, product people, policy people, and lawyers who are no longer afraid of losing their rent if they choose lower-paid work. That is a rare kind of freedom. Do not waste it on becoming marginally richer inside a company that already has more money than most governments.
+
+Go into public service. Join a city department that cannot hire enough technical talent. Work on procurement, benefits, housing, health care access, transit reliability, public records, language access, emergency response, disability services, or civic security. Help a public-interest newsroom build safer intake. Help a legal aid organization protect sources and clients. Help a union, a clinic, a tenant group, a school, or a community technology project stop drowning in bad software.
+
+If you cannot leave, give. If you cannot give much time, give serious money. If you cannot give serious money, stop pretending you are the protagonist of a civic comeback while the people doing the work run on fumes.
+
+## Support Open Source Like You Depend On It
+
+The AI boom depends on open source. It depends on languages, libraries, operating systems, databases, cryptography packages, browsers, standards, documentation, test frameworks, maintainers, and security researchers who have been subsidizing private wealth creation for years.
+
+So support open-source projects in a way that matches the scale of your liquidity.
+
+Not a star. Not a thank-you post. Not a $25 sponsorship that you forget exists. Fund maintenance. Fund audits. Fund boring infrastructure. Fund documentation. Fund security fixes. Fund the people who answer issues, rotate keys, triage CVEs, and keep old systems alive because the internet quietly depends on them.
+
+If you are about to become a multimillionaire because a speculative market believes your employer might own the future, you can afford to help the people keeping the present from breaking.
+
+## Why This Matters To Hush Line
+
+Hush Line is open-source whistleblowing infrastructure. We build tools for people who need to report wrongdoing without exposing themselves to unnecessary retaliation, surveillance, or confusion. We serve journalists, lawyers, educators, activists, workers, students, organizers, and institutions that need safer intake.
+
+That includes accountability inside AI companies.
+
+As AI systems become more powerful, more embedded, more profitable, and more politically protected, the public will need ways to hear from the people who see the gap between the demo and the deployment. Workers will see safety shortcuts before the public does. Contractors will see labor abuses before executives acknowledge them. Researchers will see evaluation failures before regulators catch up. Security teams will see incidents that do not fit the launch narrative. People inside these companies will know things the rest of us need to know.
+
+Those people need safe channels. Newsrooms need verified, usable, encrypted ways to receive tips. Public-interest lawyers need intake paths that do not force sources into insecure email threads. Civil society needs infrastructure that is not owned by the same companies it may need to scrutinize.
+
+That is what Hush Line is trying to provide.
+
+We are not building this because it is fashionable. We are building it because accountability requires infrastructure, and infrastructure requires money, maintenance, and people willing to do unglamorous work before a crisis.
+
+## A Direct Ask
+
+If you are about to become wealthy from SpaceX, Anthropic, OpenAI, or the broader AI boom, do not wait for a better tax system to make you useful.
+
+Do something now.
+
+Donate meaningful money to public-interest work in San Francisco. Fund open-source security and privacy tools. Support local journalism. Back legal aid. Help organizations that serve people in Union Square, the Tenderloin, Civic Center, SoMa, Bayview, the Mission, and every neighborhood that gets described as someone else's problem until a donor gala needs a theme.
+
+And support Hush Line.
+
+Use your money to keep independent whistleblowing infrastructure alive. Use your network to introduce us to donors who understand that AI accountability will not happen through press releases. Use your skills to improve open-source tools that protect people who speak up. If you want to make a serious gift or help us find one, [contact Hush Line directly](https://tips.hushline.app/to/admin).
+
+The city may not get the IPO tax. It may not get the Overpaid CEO Act. It may not get the clean, satisfying policy answer that turns private windfalls into public repair.
+
+So the obligation moves closer to you.
+
+If this boom makes you rich, prove that you understand what that means. Not eventually. Not after one more vest. Not after the house, the second house, the angel fund, and the long vacation.
+
+Now.


### PR DESCRIPTION
### What changed
- Adds a new Hush Line blog article, `If AI Makes You Rich, San Francisco Still Needs You`.
- Frames the piece as a tough-love donor call to action for AI and SpaceX/Anthropic/OpenAI equity windfalls.
- References current reporting on AI IPO wealth pressure, the failed San Francisco IPO-tax effort, and the failed Overpaid CEO Act / Prop D.
- Ends with a direct Hush Line support CTA tied to AI accountability and whistleblowing infrastructure.

### Why
The article is timely around reported SpaceX, Anthropic, and OpenAI IPO activity and the local debate over whether San Francisco will benefit from the resulting private wealth. It pushes newly wealthy tech workers toward public service, open-source support, local civic giving, and Hush Line funding.

### Validation
- `npm run build` from `docs/` passed.

### Manual testing
- Not applicable beyond Docusaurus build validation for this content-only article.

### Published website output
- scidsg/hushline-website#88 publishes the generated `/library/` build output for this article.